### PR TITLE
Don't use a list in a keyword argument

### DIFF
--- a/flask_hooker/hooker.py
+++ b/flask_hooker/hooker.py
@@ -5,7 +5,7 @@ from flask import Blueprint, jsonify, request
 class Hooker(object):
     """Docs here."""
 
-    def __init__(self, app=None, name='hooker', url_prefix='/webhooks', methods=['GET', 'POST']):
+    def __init__(self, app=None, name='hooker', url_prefix='/webhooks', methods=('GET', 'POST')):
         """Create the Hooker object."""
         self._app = app
         self._name = name


### PR DESCRIPTION
Using lists as default keyword arguments is a bit sketchy as they could be modified by accident and thus effect future invocations. Use a tuple, it's safer.